### PR TITLE
Update qwt_date_scale_engine.cpp

### DIFF
--- a/src/qwt_date_scale_engine.cpp
+++ b/src/qwt_date_scale_engine.cpp
@@ -418,7 +418,7 @@ static QList< double > qwtDstTicks( const QDateTime& dateTime,
     int secondsMajor, int secondsMinor )
 {
     if ( secondsMinor <= 0 )
-        QList< double >();
+        return QList< double >();
 
     QDateTime minDate = dateTime.addSecs( -secondsMajor );
     minDate = QwtDate::floor( minDate, QwtDate::Hour );


### PR DESCRIPTION
fix 
qwtDstTicks( const QDateTime& dateTime, int secondsMajor, int secondsMinor ) return value error